### PR TITLE
ohm-session-agent: Allow D-Bus activation only through systemd

### DIFF
--- a/ohm-session-agent/org.freedesktop.ohm_session_agent.service
+++ b/ohm-session-agent/org.freedesktop.ohm_session_agent.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.ohm_session_agent
-Exec=/usr/bin/ohm-session-agent
+Exec=/bin/false
 SystemdService=ohm-session-agent.service


### PR DESCRIPTION
Starting D-Bus services should happen only via systemd. Using a dummy
Exec line in D-Bus configuration ensures that systemd can't be bypassed.

[ambienced] Allow D-Bus activation only through systemd. JB#52572

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>