### PR TITLE
add all variables pkg-config .in templates

### DIFF
--- a/plugins/mdm/ohm-ext-mdm.pc.in
+++ b/plugins/mdm/ohm-ext-mdm.pc.in
@@ -1,3 +1,6 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
 includedir=@includedir@
 
 Name: ohm-ext-mdm

--- a/plugins/route/ohm-ext-route.pc.in
+++ b/plugins/route/ohm-ext-route.pc.in
@@ -1,3 +1,6 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
 includedir=@includedir@
 
 Name: ohm-ext-route


### PR DESCRIPTION
The already present `includedir=@includedir@` is substituted to `includedir=${prefix}/include`, the `prefix` variable is not set. In the end is the header files searched in `/include/` instead of `/usr/include`

The tutorial at https://autotools.io/pkgconfig/file-format.html suggest using
```
prefix=@prefix@
exec_prefix=@exec_prefix@
libdir=@libdir@
includedir=@includedir@
```

It seems the `-L` is not used here, but it will probably avoid some confusion if it is added in future.